### PR TITLE
Security rules only chats

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,16 +1,21 @@
-   {
-     "rules": {
-       "Chats": {
-         "$user1": {
-              ".read": "auth.uid === $user1",
-              ".write": "auth.uid === $user1",
-              ".validate": true
-          }
-        },
-        "$other": {
-          ".read": true,
-          ".write": true,
+  {
+    "rules": {
+      "Chats": {
+        "$user1": {
+          "$user2": {
+            ".read": "auth.uid === $user1 || auth.uid === $user2",
+            ".write": "auth.uid === $user1 || auth.uid === $user2",
+            ".validate": true
+          },
+          ".read": "auth.uid === $user1",
+          ".write": "auth.uid === $user1",
           ".validate": true
         }
+      },
+      "$other": {
+        ".read": true,
+        ".write": true,
+        ".validate": true
       }
     }
+  }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,18 @@
+   {
+     "rules": {
+       "Users": {
+        "$userId": {
+          ".read": true,
+          ".write": true,
+          ".validate": true
+        }
+       },
+       "Chats": {
+         "$user1": {
+              ".read": "auth.uid === $user1",
+              ".write": "auth.uid === $user1",
+              ".validate": true
+          }
+        }
+      }
+    }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,18 +1,16 @@
    {
      "rules": {
-       "Users": {
-        "$userId": {
-          ".read": true,
-          ".write": true,
-          ".validate": true
-        }
-       },
        "Chats": {
          "$user1": {
               ".read": "auth.uid === $user1",
               ".write": "auth.uid === $user1",
               ".validate": true
           }
+        },
+        "$other": {
+          ".read": true,
+          ".write": true,
+          ".validate": true
         }
       }
     }

--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,7 @@
       "**/node_modules/**"
     ]
   },
+  "pubsub": {},
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
@@ -22,5 +23,25 @@
   },
   "database": {
     "rules": "database.rules.json"
+  },
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "database": {
+      "port": 9000
+    },
+    "hosting": {
+      "port": 5000
+    },
+    "pubsub": {
+      "port": 8085
+    },
+    "ui": {
+      "enabled": true
+    }
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -19,5 +19,7 @@
   },
   "functions": {
     "source": "firebase-functions"
+  },
+  "database": {
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -21,5 +21,6 @@
     "source": "firebase-functions"
   },
   "database": {
+    "rules": "database.rules.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "dev": "quasar dev -m pwa",
     "icons": "icongenie generate -i logo_icongenie.png --skip-trim --theme-color FCBA03",
-    "deploy": "quasar build -m pwa && firebase deploy"
+    "deploy": "quasar build -m pwa && firebase deploy",
+    "deploy-security-rules": "firebase deploy -P cycle-planet-292f5 --only database"
   },
   "dependencies": {
     "@firebase/firestore": "^2.1.7",

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -48,13 +48,21 @@ const mutations = {
 
 const actions = {
   firebaseGetUsers({ commit }) {
+	  console.log('firebaseGetUsers called')
 
-		if(firebase.auth.currentUser){
+		if (firebase.auth.currentUser) {
+			console.log('Current user check passed')
 
-		let myUserId = firebase.auth.currentUser.uid
+			let myUserId = firebase.auth.currentUser.uid
+			const chats = firebase.db.ref('Chats/' + myUserId).get().then(chats => {
+				console.log(`Got chats structure for current user ${myUserId}`, chats)
+			}).catch(err => {
+				console.log(`No luck reading chats for user ${myUserId}`, err)
+			})
 			firebase.db.ref('Chats/'+myUserId).on('child_added', snapshot => {
 				let messageDetails = snapshot.val()
 				let userId = snapshot.key
+				console.log(`Chat added for user ${userId}`)
 				commit('addChatlist', {
 					userId,
 					messageDetails

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -191,7 +191,11 @@ const actions = {
 	payload.message.from = 'them'
 	payload.message.read = false
 	
-    firebase.db.ref('Chats/' + payload.otherUserId + '/' + userId + '/' + timeStamp).set(payload.message)
+    firebase.db.ref('Chats/' + payload.otherUserId + '/' + userId + '/' + timeStamp).set(payload.message).then(res => {
+		console.log('Chat saved for other user')
+	}).catch(err => {
+		console.warn('Could not save chat for other user', err)
+	})
 
   },
   firebaseSendHostRequest({dispatch }, payload) {

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -48,21 +48,13 @@ const mutations = {
 
 const actions = {
   firebaseGetUsers({ commit }) {
-	  console.log('firebaseGetUsers called')
 
 		if (firebase.auth.currentUser) {
-			console.log('Current user check passed')
 
 			let myUserId = firebase.auth.currentUser.uid
-			const chats = firebase.db.ref('Chats/' + myUserId).get().then(chats => {
-				console.log(`Got chats structure for current user ${myUserId}`, chats)
-			}).catch(err => {
-				console.log(`No luck reading chats for user ${myUserId}`, err)
-			})
 			firebase.db.ref('Chats/'+myUserId).on('child_added', snapshot => {
 				let messageDetails = snapshot.val()
 				let userId = snapshot.key
-				console.log(`Chat added for user ${userId}`)
 				commit('addChatlist', {
 					userId,
 					messageDetails


### PR DESCRIPTION
This makes it so that people, even if they are determined and tech-savvy, cannot read other peoples' chats.

The file `database.rules.json` in the project root that's added in this pull request contains [Security Rules](https://firebase.google.com/docs/rules) that describe who can read and write what to the Firebase Realtime Database.

This file is referenced from `firebase.json`. It can be deployed to Google's servers by doing `npm run deploy-security-rules`. Only people with the appropriate permissions on the Cycle Planet project in Firebase can do this.

After that, Google's servers will reject any write or read that is not permitted by these rules. As the check against the rules is executed on the server, no amount of playing around with the Javascript Console or altering the source code should allow people to get around this check. Only admins of the Cycle Planet project can work around the security rules, either by using the UI of the Firebase Console or by deploying new Security  Rules.