### PR TITLE
Security rules for /Users

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,21 +1,54 @@
-  {
-    "rules": {
-      "Chats": {
-        "$user1": {
-          "$user2": {
-            ".read": "auth.uid === $user1 || auth.uid === $user2",
-            ".write": "auth.uid === $user1 || auth.uid === $user2",
-            ".validate": true
-          },
-          ".read": "auth.uid === $user1",
-          ".write": "auth.uid === $user1",
+{
+  "rules": {
+    "Chats": {
+      "$user1": {
+        "$user2": {
+          ".read": "auth.uid === $user1 || auth.uid === $user2",
+          ".write": "auth.uid === $user1 || auth.uid === $user2",
           ".validate": true
-        }
-      },
-      "$other": {
-        ".read": true,
-        ".write": true,
+        },
+        ".read": "auth.uid === $user1",
+        ".write": "auth.uid === $user1",
         ".validate": true
       }
+    },
+    "Users": {
+      "$userId": {
+        "hosting": {
+          "requests": {
+            "$timestamp": {
+              // nice rules, stating that only the sender and the receiver have access to host requests.
+              // Currently, at least for reads, overruled by the rules for /Users/<userId> below.
+              ".read": "auth.uid === $userId || auth.uid === data.child('sender').val()",
+              ".write": "auth.uid === $userId || auth.uid === newData.child('sender').val()",
+              ".validate": true
+            }
+          }
+        },
+
+        // I believe we have to allow everyone to read user profiles atm.
+        // This is problematic though, as it will disclose details people
+        // don't necessarily want disclosed, like their exact geo location
+        // or their full hosting history (which, if I have to press it for
+        // examples why you may want to hide it, may include celebrities).
+        //
+        // This permissive read rule also overrules the restrictive one on
+        // hosting requests above for now.
+        //
+        // Ideally, I (Reinier) believe we'll have separate nodes /Users
+        // (all information the platform has about a user) and /Profiles
+        // (all information other people are allowed to see about this user).
+        // And then platform users could manage to some extent how much of
+        //  what's in their /Users appears in their /Profile too or not.
+        ".read": true,
+        ".write": "auth.uid === $userId",
+        ".validate": true
+      }
+    },
+    "$other": {
+      ".read": true,
+      ".write": true,
+      ".validate": true
     }
   }
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -43,7 +43,10 @@
         ".read": true,
         ".write": "auth.uid === $userId",
         ".validate": true
-      }
+      },
+      ".read": true,
+      ".write": false,
+      ".validate": true
     },
     "$other": {
       ".read": true,

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,16 +1,21 @@
-   {
-     "rules": {
-       "Chats": {
-         "$user1": {
-              ".read": "auth.uid === $user1",
-              ".write": "auth.uid === $user1",
-              ".validate": true
-          }
-        },
-        "$other": {
-          ".read": true,
-          ".write": true,
+  {
+    "rules": {
+      "Chats": {
+        "$user1": {
+          "$user2": {
+            ".read": "auth.uid === $user1 || auth.uid === $user2",
+            ".write": "auth.uid === $user1 || auth.uid === $user2",
+            ".validate": true
+          },
+          ".read": "auth.uid === $user1",
+          ".write": "auth.uid === $user1",
           ".validate": true
         }
+      },
+      "$other": {
+        ".read": true,
+        ".write": true,
+        ".validate": true
       }
     }
+  }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,18 @@
+   {
+     "rules": {
+       "Users": {
+        "$userId": {
+          ".read": true,
+          ".write": true,
+          ".validate": true
+        }
+       },
+       "Chats": {
+         "$user1": {
+              ".read": "auth.uid === $user1",
+              ".write": "auth.uid === $user1",
+              ".validate": true
+          }
+        }
+      }
+    }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,18 +1,16 @@
    {
      "rules": {
-       "Users": {
-        "$userId": {
-          ".read": true,
-          ".write": true,
-          ".validate": true
-        }
-       },
        "Chats": {
          "$user1": {
               ".read": "auth.uid === $user1",
               ".write": "auth.uid === $user1",
               ".validate": true
           }
+        },
+        "$other": {
+          ".read": true,
+          ".write": true,
+          ".validate": true
         }
       }
     }

--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,7 @@
       "**/node_modules/**"
     ]
   },
+  "pubsub": {},
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
@@ -22,5 +23,25 @@
   },
   "database": {
     "rules": "database.rules.json"
+  },
+  "emulators": {
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "database": {
+      "port": 9000
+    },
+    "hosting": {
+      "port": 5000
+    },
+    "pubsub": {
+      "port": 8085
+    },
+    "ui": {
+      "enabled": true
+    }
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -19,5 +19,7 @@
   },
   "functions": {
     "source": "firebase-functions"
+  },
+  "database": {
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -21,5 +21,6 @@
     "source": "firebase-functions"
   },
   "database": {
+    "rules": "database.rules.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "dev": "quasar dev -m pwa",
     "icons": "icongenie generate -i logo_icongenie.png --skip-trim --theme-color FCBA03",
-    "deploy": "quasar build -m pwa && firebase deploy"
+    "deploy": "quasar build -m pwa && firebase deploy",
+    "deploy-security-rules": "firebase deploy -P cycle-planet-292f5 --only database"
   },
   "dependencies": {
     "@firebase/firestore": "^2.1.7",

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -48,13 +48,21 @@ const mutations = {
 
 const actions = {
   firebaseGetUsers({ commit }) {
+	  console.log('firebaseGetUsers called')
 
-		if(firebase.auth.currentUser){
+		if (firebase.auth.currentUser) {
+			console.log('Current user check passed')
 
-		let myUserId = firebase.auth.currentUser.uid
+			let myUserId = firebase.auth.currentUser.uid
+			const chats = firebase.db.ref('Chats/' + myUserId).get().then(chats => {
+				console.log(`Got chats structure for current user ${myUserId}`, chats)
+			}).catch(err => {
+				console.log(`No luck reading chats for user ${myUserId}`, err)
+			})
 			firebase.db.ref('Chats/'+myUserId).on('child_added', snapshot => {
 				let messageDetails = snapshot.val()
 				let userId = snapshot.key
+				console.log(`Chat added for user ${userId}`)
 				commit('addChatlist', {
 					userId,
 					messageDetails

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -191,7 +191,11 @@ const actions = {
 	payload.message.from = 'them'
 	payload.message.read = false
 	
-    firebase.db.ref('Chats/' + payload.otherUserId + '/' + userId + '/' + timeStamp).set(payload.message)
+    firebase.db.ref('Chats/' + payload.otherUserId + '/' + userId + '/' + timeStamp).set(payload.message).then(res => {
+		console.log('Chat saved for other user')
+	}).catch(err => {
+		console.warn('Could not save chat for other user', err)
+	})
 
   },
   firebaseSendHostRequest({dispatch }, payload) {

--- a/src/store/store-chat.js
+++ b/src/store/store-chat.js
@@ -48,21 +48,13 @@ const mutations = {
 
 const actions = {
   firebaseGetUsers({ commit }) {
-	  console.log('firebaseGetUsers called')
 
 		if (firebase.auth.currentUser) {
-			console.log('Current user check passed')
 
 			let myUserId = firebase.auth.currentUser.uid
-			const chats = firebase.db.ref('Chats/' + myUserId).get().then(chats => {
-				console.log(`Got chats structure for current user ${myUserId}`, chats)
-			}).catch(err => {
-				console.log(`No luck reading chats for user ${myUserId}`, err)
-			})
 			firebase.db.ref('Chats/'+myUserId).on('child_added', snapshot => {
 				let messageDetails = snapshot.val()
 				let userId = snapshot.key
-				console.log(`Chat added for user ${userId}`)
 				commit('addChatlist', {
 					userId,
 					messageDetails


### PR DESCRIPTION
Extends the security rules from pull request #4 to also provide write protection to user data. So only the users themselves can edit their data, except host requests, which can also be created and updated by the one who is requesting the hosting.

Read protection to user data is going to be more complicated as we'd have to pick apart the user data which should be readable to other users from the user data that should not be. That's a bit more involved and I'm going to have a look what my next step is going to be.

These rules, like the previous version, have been deployed already (by accident this time, hitting the wrong key combo in the Security Rules Playground).