### PR TITLE
Improving privacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cpq",
-  "version": "2.0.03",
+  "version": "2.0.04",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cpq",
-      "version": "2.0.03",
+      "version": "2.0.04",
       "dependencies": {
         "@firebase/firestore": "^2.1.7",
         "@quasar/extras": "^1.0.0",
@@ -33,6 +33,7 @@
         "vue-class-component": "^7.2.6",
         "vue-clipboard2": "^0.3.1",
         "vue-croppa": "^1.3.8",
+        "vue-recaptcha": "^1.3.0",
         "vue-socialmedia-share": "^1.0.1",
         "vue2-filters": "^0.11.0",
         "vue2-leaflet": "^2.7.0",
@@ -15680,6 +15681,14 @@
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
+      }
+    },
+    "node_modules/vue-recaptcha": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vue-recaptcha/-/vue-recaptcha-1.3.0.tgz",
+      "integrity": "sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
       }
     },
     "node_modules/vue-router": {
@@ -31449,6 +31458,12 @@
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
       }
+    },
+    "vue-recaptcha": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vue-recaptcha/-/vue-recaptcha-1.3.0.tgz",
+      "integrity": "sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA==",
+      "requires": {}
     },
     "vue-router": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "vue-class-component": "^7.2.6",
     "vue-clipboard2": "^0.3.1",
     "vue-croppa": "^1.3.8",
+    "vue-recaptcha": "^1.3.0",
     "vue-socialmedia-share": "^1.0.1",
     "vue2-filters": "^0.11.0",
     "vue2-leaflet": "^2.7.0",

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -7,6 +7,9 @@
 [v-cloak] {
   display: none !important;
 }
+a {
+  color: red;
+}
 .underline{
   text-decoration: underline;
 }

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -36,6 +36,11 @@
     integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
     crossorigin=""></script>
 
+    <script src="https://unpkg.com/vue-recaptcha@latest/dist/vue-recaptcha.js"></script>
+<!-- Minify -->
+<script src="https://unpkg.com/vue-recaptcha@latest/dist/vue-recaptcha.min.js"></script>
+
+
   <link rel="icon" type="image/png" sizes="128x128" href="icons/favicon-128x128.png">
   <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png">

--- a/src/pages/Other/PageCookiePolicy.vue
+++ b/src/pages/Other/PageCookiePolicy.vue
@@ -1,9 +1,75 @@
 <template>
   <q-page   >
     <div class="q-pa-md">
-      <p class="text-h4">Cookie policy</p>
+      <p class="text-h4">Cookie policy for cycleplanet.org</p>
       <q-separator class="q-my-sm" />
-      <p class="text-body1">We don't use cookies to track your information. Instead, we prefer to eat cookies. Tell us about your favourite cookie, or send us some ;)</p>
+
+<p>This is the Cookie Policy for cycleplanet.org, accessible from https://cycleplanet.org/</p>
+
+<p><strong>What Are Cookies</strong></p>
+
+<p>As is common practice with almost all professional websites this site uses cookies, which are tiny files that are downloaded to your computer, to improve your experience. This page describes what information they gather, how we use it and why we sometimes need to store these cookies. We will also share how you can prevent these cookies from being stored however this may downgrade or 'break' certain elements of the sites functionality.</p>
+
+<p><strong>How We Use Cookies</strong></p>
+
+<p>We use cookies for a variety of reasons detailed below. Unfortunately in most cases there are no industry standard options for disabling cookies without completely disabling the functionality and features they add to this site. It is recommended that you leave on all cookies if you are not sure whether you need them or not in case they are used to provide a service that you use.</p>
+
+<p><strong>Disabling Cookies</strong></p>
+
+<p>You can prevent the setting of cookies by adjusting the settings on your browser (see your browser Help for how to do this). Be aware that disabling cookies will affect the functionality of this and many other websites that you visit. Disabling cookies will usually result in also disabling certain functionality and features of the this site. Therefore it is recommended that you do not disable cookies.</p>
+<p><strong>The Cookies We Set</strong></p>
+
+<ul>
+
+<li>
+    <p>Account related cookies</p>
+    <p>If you create an account with us then we will use cookies for the management of the signup process and general administration. These cookies will usually be deleted when you log out however in some cases they may remain afterwards to remember your site preferences when logged out.</p>
+</li>
+
+<li>
+    <p>Login related cookies</p>
+    <p>We use cookies when you are logged in so that we can remember this fact. This prevents you from having to log in every single time you visit a new page. These cookies are typically removed or cleared when you log out to ensure that you can only access restricted features and areas when logged in.</p>
+</li>
+
+<li>
+    <p>Email newsletters related cookies</p>
+    <p>This site offers newsletter or email subscription services and cookies may be used to remember if you are already registered and whether to show certain notifications which might only be valid to subscribed/unsubscribed users.</p>
+</li>
+
+
+
+
+
+</ul>
+
+<p><strong>Third Party Cookies</strong></p>
+
+<p>In some special cases we also use cookies provided by trusted third parties. The following section details which third party cookies you might encounter through this site.</p>
+
+<ul>
+
+<li>
+    <p>This site uses Google Analytics which is one of the most widespread and trusted analytics solution on the web for helping us to understand how you use the site and ways that we can improve your experience. These cookies may track things such as how long you spend on the site and the pages that you visit so we can continue to produce engaging content.</p>
+    <p>For more information on Google Analytics cookies, see the official Google Analytics page.</p>
+</li>
+
+<li>
+    <p>Third party analytics are used to track and measure usage of this site so that we can continue to produce engaging content. These cookies may track things such as how long you spend on the site or pages you visit which helps us to understand how we can improve the site for you.</p>
+</li>
+
+<li>
+    <p>From time to time we test new features and make subtle changes to the way that the site is delivered. When we are still testing new features these cookies may be used to ensure that you receive a consistent experience whilst on the site whilst ensuring we understand which optimisations our users appreciate the most.</p>
+</li>
+
+</ul>
+
+<p><strong>More Information</strong></p>
+
+<p>Hopefully that has clarified things for you and as was previously mentioned if there is something that you aren't sure whether you need or not it's usually safer to leave cookies enabled in case it does interact with one of the features you use on our site.</p>
+
+<p>However if you are still looking for more information then you can contact us through one of our preferred contact methods:</p>
+
+<div>Email:<a href="mailto: info@cycleplanet.org">info@cycleplanet.org</a></div>
     </div>
   </q-page>
 </template>

--- a/src/pages/PageAuth.vue
+++ b/src/pages/PageAuth.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page class="q-pa-sm">
     <q-card class="auth-tabs">
-      <q-tabs  v-model="tab" dense class="text-accent"   narrow-indicator align="justify" active-color="secondary" indicator-color="secondary">
+      <q-tabs  v-model="tab" align="justify" active-color="secondary bg-teal-1" indicator-color="secondary">
         <q-tab name="login" label="Login" />
         <q-tab name="register" label="Register"/>
       </q-tabs>
@@ -103,6 +103,11 @@
                   :rules="[ val => isValidEmailAddress || 'Please enter a valid email address']"
                   lazy-rules />
                 </div>
+                <div class="row items-center q-mb-md">
+                  <q-toggle v-model="accept" class="col-2"/>
+                  <div class="col-10">I agree to the <a v-bind:href="'/cookie-policy'" target="_blank">Cookie Policy</a> , <a v-bind:href="'/privacy-policy'">Privacy Policy</a> and <a v-bind:href="'/terms-of-use'">Terms of Use</a></div>
+                </div>
+               
                 <div class="row">
                    
                     <q-space/>
@@ -117,7 +122,9 @@
                 </div>
             </q-form>  
         </q-tab-panel>
-        
+         <vue-recaptcha sitekey="6LcfDKobAAAAAJjKcuVB9_AhtU8O-IHIwLbLaUDW">
+                  <button>Click me</button>
+                </vue-recaptcha>
       </q-tab-panels>
     </q-card>
 
@@ -164,23 +171,31 @@
 <script>
 import mixinGeneral from 'src/mixins/mixin-general.js'
 import {mapActions} from 'vuex'
+import { date, uid, Notify } from 'quasar'
+import VueRecaptcha from 'vue-recaptcha'
 
 export default {
   	mixins: [mixinGeneral],
    
   data () {
     return {
-      tab: 'login',
+      tab: 'register',
       emailDialog:false,
       forgotPasswordDialog:false,
       error: null,
+      accept:false,
       formData:{
           email:'',
           password:'',
           name:''
       }
+      
     }
   },
+  components:{
+    VueRecaptcha 
+  },
+
   methods:{
       ...mapActions('auth',['registerUser','loginUser','resetPassword']),
       submitForm(){
@@ -190,10 +205,19 @@ export default {
               if(this.tab=='login'){
                   this.loginUser(this.formData)
               }else{
-                  
+                if (this.accept.value !== true) {
+                  this.$q.notify({
+                    color: 'red-5',
+                    textColor: 'white',
+                    icon: 'warning',
+                    message: 'You need to accept the Cookie Policy, Privacy Policy and Terms of Use'
+                  })
+                }else{
                   this.emailDialog=true
                   this.tab='login'
                   this.registerUser(this.formData)
+                }
+               
                   
               }
           }
@@ -215,7 +239,8 @@ export default {
 
 <style>
 .auth-tabs{
-    max-width: 500px;
+    max-width: 600px;
     margin:0 auto;
 }
+
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10029,6 +10029,11 @@
     "vue-hot-reload-api" "^2.3.0"
     "vue-style-loader" "^4.1.0"
 
+"vue-recaptcha@^1.3.0":
+  "integrity" "sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA=="
+  "resolved" "https://registry.npmjs.org/vue-recaptcha/-/vue-recaptcha-1.3.0.tgz"
+  "version" "1.3.0"
+
 "vue-router@3.2.0":
   "integrity" "sha512-khkrcUIzMcI1rDcNtqkvLwfRFzB97GmJEsPAQdj7t/VvpGhmXLOkUfhc+Ah8CvpSXGXwuWuQO+x8Sy/xDhXZIA=="
   "resolved" "https://registry.npmjs.org/vue-router/-/vue-router-3.2.0.tgz"
@@ -10077,7 +10082,7 @@
   "resolved" "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz"
   "version" "1.9.1"
 
-"vue@^2.5.16", "vue@^2.6.10", "vue@^2.6.12", "vue@2.6.12":
+"vue@^2.0.0", "vue@^2.5.16", "vue@^2.6.10", "vue@^2.6.12", "vue@2.6.12":
   "integrity" "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
   "resolved" "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz"
   "version" "2.6.12"


### PR DESCRIPTION
Trying to heavily improve the privacy regulations and protection of Cycle Planet. First of all, the documents [Cookie Policy](https://cycleplanet.org/cookie-policy), [Privacy Policy](https://cycleplanet.org/privacy-policy) and [Terms of Use](https://cycleplanet.org/terms-of-use) have to adjusted and make it according the official regulations. @reinierl has already started writing a document in which is described how we use the user's data. The next step is to translate this document to legal policies that should assure registered users about the legal terms. 

Also, trying to integrate a recaptcha in here, as described in #7. Account has been made and a key is generated. For now it's still in `PageAuth.vue`, but it should be places in the `config.js file`. The recaptcha makes use of [this ](https://github.com/DanSnow/vue-recaptcha) plugin, but is not working correctly yet. Users now also have to agree with all 3 policies before they can make an account.

More things we need to take into consideration?