### PR TITLE
Add AppCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "core-js": "^3.6.5",
     "cpq-shared": "file:firebase-functions/shared",
     "emailjs-com": "^2.6.4",
-    "firebase": "^8.5.0",
+    "firebase": "^8.10.0",
     "firebase-admin": "9.4.2",
     "leaflet": "^1.7.1",
     "leaflet-gpx": "^1.5.2",

--- a/src/boot/config.example.js
+++ b/src/boot/config.example.js
@@ -32,6 +32,15 @@ const emailjskey = {
 
 const firebaseApp = fb.initializeApp(firebaseConfig);
 
+const appCheck = firebase.appCheck();
+
+appCheck.activate(
+  // reCAPTCHA v3 site key (public key) to activate()
+  "",
+  // Optional argument. If true, the SDK automatically refreshes App Check
+  // tokens as needed.
+  true);
+
 const firebase = {
   app: firebaseApp,
   auth: firebaseApp.auth(),


### PR DESCRIPTION
Following [Firebase's App Check for web app doc](https://firebase.google.com/docs/app-check/web/recaptcha-provider).

Not tested, someone with an access to the CP account needs to:

1. [Register site for reCAPTCHA v3](https://www.google.com/recaptcha/admin/create) and get reCAPTCHA v3 site key and secret key.
2. Register app to use App Check with the reCAPTCHA provider in the Project Settings > App Check section of the Firebase console. You will need to provide the secret key you got in the previous step.